### PR TITLE
Support env var for building local freetype

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,9 @@ if __name__ == '__main__':
         if config.has_option('test', 'local_freetype'):
             local_freetype = True
 
+    local_freetype = (('FREETYPY_LOCAL_FREETYPE' in os.environ) or
+                      local_freetype)
+
     cmdclass = versioneer.get_cmdclass()
     OriginalBuildExt = cmdclass.get('build_ext', BuildExtCommand)
 


### PR DESCRIPTION
This is so we can create a local freetype build through pip, e.g.

```
FREETYPY_LOCAL_FREETYPE=True pip install freetypy
```